### PR TITLE
filter out excluded resources in lists and print only exported resorces

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,4 +58,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: --skip-publish --snapshot --rm-dist
+          args: --skip-publish --snapshot --clean

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ exports
 dist
 kubexporter
 gomock_*
+bin

--- a/Makefile
+++ b/Makefile
@@ -16,25 +16,61 @@ test: tidy fmt vet
 	go test ./...  -coverprofile=coverage.out
 	go tool cover -func=coverage.out
 
-release: semver
-	@version=$$(semver); \
+release: semver goreleaser
+	@version=$$($(LOCALBIN)/semver); \
 	git tag -s $$version -m"Release $$version"
-	goreleaser --clean
+	$(GORELEASER) --clean
 
-test-release:
-	goreleaser --skip-publish --snapshot --clean
+
+test-release: goreleaser
+	$(GORELEASER)  --skip-publish --snapshot --clean
 
 # generate mocks
 mocks: mockgen
-	mockgen -destination pkg/mocks/client/mock.go   k8s.io/client-go/dynamic Interface
-	mockgen -destination pkg/mocks/mapper/mock.go   k8s.io/apimachinery/pkg/api/meta RESTMapper
+	$(MOCKGEN) -destination pkg/mocks/client/mock.go   k8s.io/client-go/dynamic Interface
+	$(MOCKGEN) -destination pkg/mocks/mapper/mock.go   k8s.io/apimachinery/pkg/api/meta RESTMapper
 
-mockgen:
-ifeq (, $(shell which mockgen))
- $(shell go get github.com/golang/mock/mockgen@v1.5.0)
-endif
+## toolbox - start
+## Current working directory
+LOCALDIR ?= $(shell which cygpath > /dev/null 2>&1 && cygpath -m $$(pwd) || pwd)
+## Location to install dependencies to
+LOCALBIN ?= $(LOCALDIR)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
 
-semver:
-ifeq (, $(shell which semver))
- $(shell go install github.com/bakito/semver@latest)
-endif
+## Tool Binaries
+SEMVER ?= $(LOCALBIN)/semver
+MOCKGEN ?= $(LOCALBIN)/mockgen
+GORELEASER ?= $(LOCALBIN)/goreleaser
+
+## Tool Versions
+SEMVER_VERSION ?= v1.1.3
+MOCKGEN_VERSION ?= v1.6.0
+GORELEASER_VERSION ?= v1.15.2
+
+## Tool Installer
+.PHONY: semver
+semver: $(SEMVER) ## Download semver locally if necessary.
+$(SEMVER): $(LOCALBIN)
+	test -s $(LOCALBIN)/semver || GOBIN=$(LOCALBIN) go install github.com/bakito/semver@$(SEMVER_VERSION)
+.PHONY: mockgen
+mockgen: $(MOCKGEN) ## Download mockgen locally if necessary.
+$(MOCKGEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/mockgen || GOBIN=$(LOCALBIN) go install github.com/golang/mock/mockgen@$(MOCKGEN_VERSION)
+.PHONY: goreleaser
+goreleaser: $(GORELEASER) ## Download goreleaser locally if necessary.
+$(GORELEASER): $(LOCALBIN)
+	test -s $(LOCALBIN)/goreleaser || GOBIN=$(LOCALBIN) go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
+
+## Update Tools
+.PHONY: update-toolbox-tools
+update-toolbox-tools:
+	@rm -f \
+		$(LOCALBIN)/semver \
+		$(LOCALBIN)/mockgen \
+		$(LOCALBIN)/goreleaser
+	toolbox makefile -f $(LOCALDIR)/Makefile \
+		github.com/bakito/semver \
+		github.com/golang/mock/mockgen \
+		github.com/goreleaser/goreleaser
+## toolbox - end

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test: tidy fmt vet
 release: semver
 	@version=$$(semver); \
 	git tag -s $$version -m"Release $$version"
-	goreleaser --rm-dist
+	goreleaser --clean
 
 test-release:
-	goreleaser --skip-publish --snapshot --rm-dist
+	goreleaser --skip-publish --snapshot --clean
 
 # generate mocks
 mocks: mockgen

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ excluded:
       - field: [ metadata, name ]
         # the value is compared to the string representation of the actual kind value
         values: [ exclude-me-1, exclude-me-2 ]
+    Secret:
+      - field: [ type ]
+        # exclude helm secrets
+        values: [ 'helm.sh/release', 'helm.sh/release.v1' ]
 # mask certain fields 
 masked:
   # the replacement string to be used for masked fields (default '***')

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -220,7 +220,7 @@ func (e *exporter) printSummary(resources []*types.GroupResource) {
 		table.Append(r.Report(e.config.Verbose && e.stats.HasErrors()))
 		qd = qd.Add(r.QueryDuration)
 		ed = ed.Add(r.ExportDuration)
-		inst += r.Instances
+		inst += r.ExportedInstances
 	}
 	total := "TOTAL"
 	if e.config.Worker > 1 {

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -11,14 +11,15 @@ import (
 
 // GroupResource group resource information
 type GroupResource struct {
-	APIGroup        string
-	APIGroupVersion string
-	APIResource     metav1.APIResource
-	APIVersion      string
-	Instances       int
-	Error           string
-	QueryDuration   time.Duration
-	ExportDuration  time.Duration
+	APIGroup          string
+	APIGroupVersion   string
+	APIResource       metav1.APIResource
+	APIVersion        string
+	Instances         int
+	ExportedInstances int
+	Error             string
+	QueryDuration     time.Duration
+	ExportDuration    time.Duration
 }
 
 // Report generate report rows
@@ -28,7 +29,7 @@ func (r GroupResource) Report(withError bool) []string {
 		r.APIVersion,
 		r.APIResource.Kind,
 		strconv.FormatBool(r.APIResource.Namespaced),
-		strconv.Itoa(r.Instances),
+		strconv.Itoa(r.ExportedInstances),
 		r.QueryDuration.String(),
 		r.ExportDuration.String(),
 	}


### PR DESCRIPTION
This PR fixes the following issued:

- Excluded resources got not filtered out in list export
- Summary and stats counted also excluded resources
- replace deprecated goreleaser flag
- update tools with [toolbox](https://github.com/bakito/toolbox) 