### PR TITLE
feat: add preserved fields functionality

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,3 +68,10 @@ excluded:
     Secret:
       - field: [type]
         values: ['helm.sh/release', 'helm.sh/release.v1']
+  # fields that should be preserved even when their parent field is excluded
+  # TODO: add kind-specific preserved fields for more fine-grained control
+  preservedFields:
+    # global preserved fields - these will be preserved when their parent field is excluded
+    fields:
+      - [status, loadBalancer, ingress]  # preserve status.loadBalancer.ingress when status is excluded
+


### PR DESCRIPTION
This PR adds the ability to exclude entire fields while preserving specific sub-fields that are needed.

- Add PreservedFields struct to Excluded configuration
- Implement field preservation logic in FilterFields method
- Add comprehensive tests for preserved fields functionality
- Integrate preserved fields configuration in config.yaml
- Preserve specific sub-fields when parent fields are excluded

This feature allows excluding entire fields (like status) while preserving specific sub-fields that are needed (like status.loadBalancer.ingress).

It can be improved at a second stage to preserve excluded fields per kind.