### PR TITLE
Enable exporting from multiple namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Flags:
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -l, --lists                          If enabled, all resources are exported as lists instead of individual files
       --include-cluster-resources      Also export cluster-scoped resources when a namespace filter is active (e.g. --include-cluster-resources=true)
-  -n, --namespace strings              Export only these namespaces, comma-separated (e.g. --namespace ns1,ns2) or repeated (e.g. --namespace ns1 --namespace ns2)
+  -n, --namespace string               Export only this namespace
+      --namespaces strings             Export only these namespaces, comma-separated (e.g. --namespaces ns1,ns2) or repeated (e.g. --namespaces ns1 --namespaces ns2)
   -o, --output string                  Output format. One of: (json, yaml). (default "yaml")
   -p, --progress string                Progress mode bar|simple|none (default bar)  (default "bar")
   -q, --quiet                          If enabled, output is prevented
@@ -114,12 +115,11 @@ archive: true
 #gcs:
 #  bucket: <your-bucket-name>
 
-# define one or more namespaces (default all)
+# define a single namespace (default all)
 namespace:
-# To limit export, replace the empty value above with either:
 #namespace: namespace-a
-# or:
-#namespace:
+# define multiple namespaces (joined with namespace, if both are set)
+#namespaces:
 #  - namespace-a
 #  - namespace-b
 # export cluster-scoped resources too when a namespace filter is active

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Flags:
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -l, --lists                          If enabled, all resources are exported as lists instead of individual files
-  -n, --namespace string               If present, the namespace scope for this CLI request
+      --include-cluster-resources      Also export cluster-scoped resources when a namespace filter is active (e.g. --include-cluster-resources=true)
+  -n, --namespace strings              Export only these namespaces, comma-separated (e.g. --namespace ns1,ns2) or repeated (e.g. --namespace ns1 --namespace ns2)
   -o, --output string                  Output format. One of: (json, yaml). (default "yaml")
   -p, --progress string                Progress mode bar|simple|none (default bar)  (default "bar")
   -q, --quiet                          If enabled, output is prevented
@@ -113,8 +114,16 @@ archive: true
 #gcs:
 #  bucket: <your-bucket-name>
 
-# define a single namespace (default all)
+# define one or more namespaces (default all)
 namespace:
+# To limit export, replace the empty value above with either:
+#namespace: namespace-a
+# or:
+#namespace:
+#  - namespace-a
+#  - namespace-b
+# export cluster-scoped resources too when a namespace filter is active
+includeClusterResources: false
 # define the number of parallel worker
 worker: 1
 # export as lists

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,8 +61,11 @@ func readConfig(
 	cmd.Flags().Visit(func(f *pflag.Flag) {
 		switch f.Name {
 		case "namespace":
+			namespace, _ := cmd.Flags().GetString(f.Name)
+			config.Namespace = namespace
+		case "namespaces":
 			namespaces, _ := cmd.Flags().GetStringSlice(f.Name)
-			config.Namespace = types.NewNamespaces(namespaces)
+			config.Namespaces = types.NewNamespaces(namespaces)
 		case "include-cluster-resources":
 			b, _ := cmd.Flags().GetBool(f.Name)
 			config.IncludeClusterResources = b
@@ -122,6 +125,7 @@ func readConfig(
 
 	config.Encrypted.KindFields = config.Masked.KindFields.Diff(config.Encrypted.KindFields)
 
+	config.Normalize()
 	correctProgressForNonTerminalRun(config)
 
 	return config, nil
@@ -167,16 +171,13 @@ func init() {
 			"Export only included kinds, if included kinds are defined, excluded will be ignored")
 	rootCmd.Flags().StringSliceP("exclude-kinds", "e", []string{}, "Do not export excluded kinds")
 	rootCmd.Flags().Duration("created-within", 0, "The max allowed age duration for the resources")
-	rootCmd.Flags().StringSliceP("namespace", "n", []string{},
+	rootCmd.Flags().StringSlice("namespaces", []string{},
 		"Export only these namespaces, comma-separated or repeated")
 	rootCmd.Flags().Bool("include-cluster-resources", false,
 		"Also export cluster-scoped resources when a namespace filter is active")
 
 	configFlags = genericclioptions.NewConfigFlags(true)
-	configFlags.Namespace = nil
 	configFlags.AddFlags(rootCmd.Flags())
-	namespace := ""
-	configFlags.Namespace = &namespace
 
 	printFlags = &genericclioptions.PrintFlags{
 		OutputFormat:       new(types.DefaultFormat),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,11 @@ func readConfig(
 	cmd.Flags().Visit(func(f *pflag.Flag) {
 		switch f.Name {
 		case "namespace":
-			config.Namespace = f.Value.String()
+			namespaces, _ := cmd.Flags().GetStringSlice(f.Name)
+			config.Namespace = types.NewNamespaces(namespaces)
+		case "include-cluster-resources":
+			b, _ := cmd.Flags().GetBool(f.Name)
+			config.IncludeClusterResources = b
 		case "target":
 			config.Target = f.Value.String()
 		case "worker":
@@ -163,9 +167,16 @@ func init() {
 			"Export only included kinds, if included kinds are defined, excluded will be ignored")
 	rootCmd.Flags().StringSliceP("exclude-kinds", "e", []string{}, "Do not export excluded kinds")
 	rootCmd.Flags().Duration("created-within", 0, "The max allowed age duration for the resources")
+	rootCmd.Flags().StringSliceP("namespace", "n", []string{},
+		"Export only these namespaces, comma-separated or repeated")
+	rootCmd.Flags().Bool("include-cluster-resources", false,
+		"Also export cluster-scoped resources when a namespace filter is active")
 
 	configFlags = genericclioptions.NewConfigFlags(true)
+	configFlags.Namespace = nil
 	configFlags.AddFlags(rootCmd.Flags())
+	namespace := ""
+	configFlags.Namespace = &namespace
 
 	printFlags = &genericclioptions.PrintFlags{
 		OutputFormat:       new(types.DefaultFormat),

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,14 @@ progress: bubbles
 archive: true
 archiveRetentionDays: 10
 archiveTarget: .
-namespace:
+# To limit export, use either:
+#namespace: namespace-a
+# or:
+# namespace:
+#   - ns1
+#   - ns2
+
+# includeClusterResources: false
 asLists: false
 #queryPageSize: 1000
 clearTarget: true

--- a/config.yaml
+++ b/config.yaml
@@ -3,14 +3,14 @@ progress: bubbles
 archive: true
 archiveRetentionDays: 10
 archiveTarget: .
-# To limit export, use either:
-#namespace: namespace-a
-# or:
-# namespace:
+# define a single namespace (default all)
+namespace:
+# namespace: ns1
+# define multiple namespaces (joined with namespace, if both are set)
+# namespaces:
 #   - ns1
 #   - ns2
-
-# includeClusterResources: false
+includeClusterResources: true
 asLists: false
 #queryPageSize: 1000
 clearTarget: true

--- a/pkg/export/archive.go
+++ b/pkg/export/archive.go
@@ -57,11 +57,11 @@ func (e *exporter) tarGz() error {
 	}
 
 	var name string
-	if e.config.Namespace != "" {
+	if e.config.HasNamespaceFilter() {
 		name = fmt.Sprintf(
 			"%s-%s-%s.tar.gz",
 			filepath.Base(e.config.Target),
-			e.config.Namespace,
+			strings.Join(e.config.NamespaceFilter(), "-"),
 			time.Now().Format(archiveTimestampPattern),
 		)
 	} else {

--- a/pkg/export/archive.go
+++ b/pkg/export/archive.go
@@ -58,10 +58,11 @@ func (e *exporter) tarGz() error {
 
 	var name string
 	if e.config.HasNamespaceFilter() {
+		firstNamespace := e.config.NamespaceFilter()[0]
 		name = fmt.Sprintf(
 			"%s-%s-%s.tar.gz",
 			filepath.Base(e.config.Target),
-			strings.Join(e.config.NamespaceFilter(), "-"),
+			firstNamespace,
 			time.Now().Format(archiveTimestampPattern),
 		)
 	} else {

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -103,10 +103,16 @@ func (e *exporter) Export(ctx context.Context) error {
 
 	var exportErr error
 	var s *worker.Stats
+	var done chan struct{}
 	if prog.Async() {
+		done = make(chan struct{})
 		go func() {
+			defer close(done)
 			s, exportErr = worker.RunExport(ctx, workers, resources)
 			e.stats.Add(s)
+		}()
+		defer func() {
+			<-done
 		}()
 	} else {
 		s, exportErr = worker.RunExport(ctx, workers, resources)
@@ -115,6 +121,9 @@ func (e *exporter) Export(ctx context.Context) error {
 
 	if err := prog.Run(); err != nil {
 		return err
+	}
+	if prog.Async() {
+		<-done
 	}
 	if exportErr != nil {
 		return exportErr
@@ -159,10 +168,13 @@ func (e *exporter) writeIntro() {
 	e.l.Printf("Starting export ...\n")
 	e.l.Printf("  kubexporter version %q\n", version.Version)
 	e.l.Printf("  cluster %q\n", e.ac.RestConfig.Host)
-	if e.config.Namespace == "" {
+	if !e.config.HasNamespaceFilter() {
 		e.l.Printf("  all namespaces 🏘️\n")
 	} else {
-		e.l.Printf("  namespace %q 🏠\n", e.config.Namespace)
+		e.l.Printf("  namespace %q 🏠\n", e.config.Namespace.String())
+		if e.config.IncludeClusterResources {
+			e.l.Printf("  include cluster resources 🌐\n")
+		}
 	}
 	e.l.Printf("  target %q 📁\n", e.config.Target)
 	e.l.Printf("  format %q 📜\n", e.config.OutputFormat())
@@ -235,7 +247,9 @@ func (e *exporter) listResources() ([]*types.GroupResource, error) {
 				APIGroupVersion: gv.String(),
 				APIResource:     resource,
 			}
-			if !allowsList(resource) || e.config.IsExcluded(r) || (!resource.Namespaced && e.config.Namespace != "") {
+			if !allowsList(resource) ||
+				e.config.IsExcluded(r) ||
+				(!resource.Namespaced && e.config.HasNamespaceFilter() && !e.config.IncludeClusterResources) {
 				continue
 			}
 

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -171,7 +171,7 @@ func (e *exporter) writeIntro() {
 	if !e.config.HasNamespaceFilter() {
 		e.l.Printf("  all namespaces 🏘️\n")
 	} else {
-		e.l.Printf("  namespace %q 🏠\n", e.config.Namespace.String())
+		e.l.Printf("  namespaces %q 🏠\n", e.config.NamespaceFilterString())
 		if e.config.IncludeClusterResources {
 			e.l.Printf("  include cluster resources 🌐\n")
 		}

--- a/pkg/export/worker/worker.go
+++ b/pkg/export/worker/worker.go
@@ -69,6 +69,9 @@ func (s *Stats) Add(o *Stats) {
 }
 
 func (s *Stats) addNamespace(ns string) {
+	if ns == "" {
+		return
+	}
 	if s.namespaces == nil {
 		s.namespaces = make(map[string]bool)
 	}
@@ -106,6 +109,7 @@ func (w *worker) Stop() Stats {
 func (w *worker) list(
 	ctx context.Context,
 	group, version, kind string,
+	namespace string,
 	continueValue string,
 ) (*unstructured.UnstructuredList, error) {
 	mapping, err := w.ac.Mapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, version)
@@ -116,7 +120,7 @@ func (w *worker) list(
 	var dr dynamic.ResourceInterface
 	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 		// namespaced resources should specify the namespace
-		dr = w.ac.Client.Resource(mapping.Resource).Namespace(w.config.Namespace)
+		dr = w.ac.Client.Resource(mapping.Resource).Namespace(namespace)
 	} else {
 		// for cluster-wide resources
 		dr = w.ac.Client.Resource(mapping.Resource)
@@ -142,11 +146,13 @@ func (w *worker) GenerateWork(
 		w.currentKind = res.GroupKind()
 		w.prog.Reset()
 
-		hasMorePages := ""
-		for {
-			hasMorePages = w.listResources(ctx, res, hasMorePages)
-			if hasMorePages == "" {
-				break
+		for _, namespace := range w.namespacesForResource(res) {
+			hasMorePages := ""
+			for {
+				hasMorePages = w.listResources(ctx, res, namespace, hasMorePages)
+				if hasMorePages == "" {
+					break
+				}
 			}
 		}
 		w.stats.Resources += res.ExportedInstances
@@ -162,7 +168,19 @@ func (w *worker) GenerateWork(
 	}
 }
 
-func (w *worker) listResources(ctx context.Context, res *types.GroupResource, hasMorePages string) string {
+func (w *worker) namespacesForResource(res *types.GroupResource) []string {
+	if res.APIResource.Namespaced {
+		return w.config.NamespaceQueryValues()
+	}
+	return []string{""}
+}
+
+func (w *worker) listResources(
+	ctx context.Context,
+	res *types.GroupResource,
+	namespace string,
+	hasMorePages string,
+) string {
 	w.currentPage = res.Pages + 1
 	w.prog.NewSearchBar(
 		progress.Step{
@@ -173,7 +191,7 @@ func (w *worker) listResources(ctx context.Context, res *types.GroupResource, ha
 		},
 	)
 	start := time.Now()
-	ul, err := w.list(ctx, res.APIGroup, res.APIVersion, res.APIResource.Kind, hasMorePages)
+	ul, err := w.list(ctx, res.APIGroup, res.APIVersion, res.APIResource.Kind, namespace, hasMorePages)
 
 	if w.prog != nil {
 		w.prog.IncrementResourceBarBy(w.id, 1)

--- a/pkg/export/worker/worker_test.go
+++ b/pkg/export/worker/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -200,6 +201,36 @@ func TestWorker_exportSingleResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorker_namespacesForResource(t *testing.T) {
+	w, _ := setupWorker(t)
+	namespaced, _ := getTestData()
+	clusterScoped := *namespaced
+	clusterScoped.APIResource.Namespaced = false
+
+	t.Run("should query all namespaces without filter", func(t *testing.T) {
+		got := w.namespacesForResource(namespaced)
+		if !reflect.DeepEqual(got, []string{""}) {
+			t.Errorf("expected all namespace query, but got %v", got)
+		}
+	})
+
+	t.Run("should query every namespace filter for namespaced resources", func(t *testing.T) {
+		w.config.Namespace = types.Namespaces{"namespace-1", "namespace-2"}
+		got := w.namespacesForResource(namespaced)
+		if !reflect.DeepEqual(got, []string{"namespace-1", "namespace-2"}) {
+			t.Errorf("expected namespace filter queries, but got %v", got)
+		}
+	})
+
+	t.Run("should query cluster scope for cluster resources", func(t *testing.T) {
+		w.config.Namespace = types.Namespaces{"namespace-1", "namespace-2"}
+		got := w.namespacesForResource(&clusterScoped)
+		if !reflect.DeepEqual(got, []string{""}) {
+			t.Errorf("expected cluster query, but got %v", got)
+		}
+	})
 }
 
 func checkDir(t *testing.T, expectedFiles int, dir ...string) []os.DirEntry {

--- a/pkg/export/worker/worker_test.go
+++ b/pkg/export/worker/worker_test.go
@@ -217,7 +217,7 @@ func TestWorker_namespacesForResource(t *testing.T) {
 	})
 
 	t.Run("should query every namespace filter for namespaced resources", func(t *testing.T) {
-		w.config.Namespace = types.Namespaces{"namespace-1", "namespace-2"}
+		w.config.Namespaces = []string{"namespace-1", "namespace-2"}
 		got := w.namespacesForResource(namespaced)
 		if !reflect.DeepEqual(got, []string{"namespace-1", "namespace-2"}) {
 			t.Errorf("expected namespace filter queries, but got %v", got)
@@ -225,7 +225,7 @@ func TestWorker_namespacesForResource(t *testing.T) {
 	})
 
 	t.Run("should query cluster scope for cluster resources", func(t *testing.T) {
-		w.config.Namespace = types.Namespaces{"namespace-1", "namespace-2"}
+		w.config.Namespaces = []string{"namespace-1", "namespace-2"}
 		got := w.namespacesForResource(&clusterScoped)
 		if !reflect.DeepEqual(got, []string{""}) {
 			t.Errorf("expected cluster query, but got %v", got)

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -162,7 +162,8 @@ type Config struct {
 	ClearTarget             bool          `json:"clearTarget"             yaml:"clearTarget"`
 	Summary                 bool          `json:"summary"                 yaml:"summary"`
 	Progress                Progress      `json:"progress"                yaml:"progress"`
-	Namespace               Namespaces    `json:"namespace"               yaml:"namespace"`
+	Namespace               string        `json:"namespace"               yaml:"namespace"`
+	Namespaces              []string      `json:"namespaces"              yaml:"namespaces"`
 	IncludeClusterResources bool          `json:"includeClusterResources" yaml:"includeClusterResources"`
 	Worker                  int           `json:"worker"                  yaml:"worker"`
 	Archive                 bool          `json:"archive"                 yaml:"archive"`
@@ -185,14 +186,36 @@ func (c *Config) MaxArchiveAge() time.Time {
 	return time.Now().AddDate(0, 0, -c.ArchiveRetentionDays)
 }
 
-// HasNamespaceFilter returns true if export is limited to one or more namespaces.
-func (c *Config) HasNamespaceFilter() bool {
-	return len(c.Namespace) > 0
+// Normalize normalizes config values after config-file and CLI overrides are applied.
+func (c *Config) Normalize() {
+	c.Namespace = strings.TrimSpace(c.Namespace)
+	c.Namespaces = normalizeNamespaces(c.Namespaces)
 }
 
-// NamespaceFilter returns the configured namespaces.
+// HasNamespaceFilter returns true if export is limited to one or more namespaces.
+func (c *Config) HasNamespaceFilter() bool {
+	return len(c.NamespaceFilter()) > 0
+}
+
+// NamespaceFilter returns the configured namespace filters.
 func (c *Config) NamespaceFilter() []string {
-	return append([]string(nil), c.Namespace...)
+	namespaces := append(slices.Clone(c.Namespaces), c.Namespace)
+
+	namespaces = slices.DeleteFunc(namespaces, func(ns string) bool {
+		return strings.TrimSpace(ns) == ""
+	})
+
+	for i, ns := range namespaces {
+		namespaces[i] = strings.TrimSpace(ns)
+	}
+
+	slices.Sort(namespaces)
+	namespaces = slices.Compact(namespaces)
+
+	if len(namespaces) == 0 {
+		return nil
+	}
+	return namespaces
 }
 
 // NamespaceQueryValues returns namespace values for Kubernetes list requests.
@@ -203,49 +226,19 @@ func (c *Config) NamespaceQueryValues() []string {
 	return c.NamespaceFilter()
 }
 
-// Namespaces is the namespace export filter.
-type Namespaces []string
-
 // NewNamespaces creates a normalized namespace filter.
-func NewNamespaces(namespaces []string) Namespaces {
+func NewNamespaces(namespaces []string) []string {
 	return normalizeNamespaces(namespaces)
 }
 
-// UnmarshalJSON supports both the legacy string form and the new list form.
-func (n *Namespaces) UnmarshalJSON(b []byte) error {
-	var value any
-	if err := json.Unmarshal(b, &value); err != nil {
-		return err
-	}
-
-	switch v := value.(type) {
-	case nil:
-		*n = nil
-	case string:
-		*n = normalizeNamespaces([]string{v})
-	case []any:
-		namespaces := make([]string, 0, len(v))
-		for _, item := range v {
-			s, ok := item.(string)
-			if !ok {
-				return errors.New("namespace must contain only strings")
-			}
-			namespaces = append(namespaces, s)
-		}
-		*n = normalizeNamespaces(namespaces)
-	default:
-		return errors.New("namespace must be a string or a list of strings")
-	}
-	return nil
+// NamespaceFilterString returns a printable namespace filter.
+func (c *Config) NamespaceFilterString() string {
+	return strings.Join(c.NamespaceFilter(), ", ")
 }
 
-func (n Namespaces) String() string {
-	return strings.Join(n, ", ")
-}
-
-func normalizeNamespaces(namespaces []string) Namespaces {
+func normalizeNamespaces(namespaces []string) []string {
 	seen := make(map[string]bool)
-	normalized := make(Namespaces, 0, len(namespaces))
+	normalized := make([]string, 0, len(namespaces))
 	for _, raw := range namespaces {
 		for ns := range strings.SplitSeq(raw, ",") {
 			ns = strings.TrimSpace(ns)
@@ -683,7 +676,7 @@ func (c *Config) fileNameInternal(res *GroupResource, namespace, name, templ str
 
 // Validate the config.
 func (c *Config) Validate() error {
-	c.Namespace = normalizeNamespaces(c.Namespace)
+	c.Normalize()
 
 	if c.FileNameTemplate == "" {
 		return errors.New("file name template must not be empty")

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -162,7 +162,8 @@ type Config struct {
 	ClearTarget             bool          `json:"clearTarget"             yaml:"clearTarget"`
 	Summary                 bool          `json:"summary"                 yaml:"summary"`
 	Progress                Progress      `json:"progress"                yaml:"progress"`
-	Namespace               string        `json:"namespace"               yaml:"namespace"`
+	Namespace               Namespaces    `json:"namespace"               yaml:"namespace"`
+	IncludeClusterResources bool          `json:"includeClusterResources" yaml:"includeClusterResources"`
 	Worker                  int           `json:"worker"                  yaml:"worker"`
 	Archive                 bool          `json:"archive"                 yaml:"archive"`
 	ArchiveRetentionDays    int           `json:"archiveRetentionDays"    yaml:"archiveRetentionDays"`
@@ -182,6 +183,83 @@ type Config struct {
 
 func (c *Config) MaxArchiveAge() time.Time {
 	return time.Now().AddDate(0, 0, -c.ArchiveRetentionDays)
+}
+
+// HasNamespaceFilter returns true if export is limited to one or more namespaces.
+func (c *Config) HasNamespaceFilter() bool {
+	return len(c.Namespace) > 0
+}
+
+// NamespaceFilter returns the configured namespaces.
+func (c *Config) NamespaceFilter() []string {
+	return append([]string(nil), c.Namespace...)
+}
+
+// NamespaceQueryValues returns namespace values for Kubernetes list requests.
+func (c *Config) NamespaceQueryValues() []string {
+	if !c.HasNamespaceFilter() {
+		return []string{""}
+	}
+	return c.NamespaceFilter()
+}
+
+// Namespaces is the namespace export filter.
+type Namespaces []string
+
+// NewNamespaces creates a normalized namespace filter.
+func NewNamespaces(namespaces []string) Namespaces {
+	return normalizeNamespaces(namespaces)
+}
+
+// UnmarshalJSON supports both the legacy string form and the new list form.
+func (n *Namespaces) UnmarshalJSON(b []byte) error {
+	var value any
+	if err := json.Unmarshal(b, &value); err != nil {
+		return err
+	}
+
+	switch v := value.(type) {
+	case nil:
+		*n = nil
+	case string:
+		*n = normalizeNamespaces([]string{v})
+	case []any:
+		namespaces := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return errors.New("namespace must contain only strings")
+			}
+			namespaces = append(namespaces, s)
+		}
+		*n = normalizeNamespaces(namespaces)
+	default:
+		return errors.New("namespace must be a string or a list of strings")
+	}
+	return nil
+}
+
+func (n Namespaces) String() string {
+	return strings.Join(n, ", ")
+}
+
+func normalizeNamespaces(namespaces []string) Namespaces {
+	seen := make(map[string]bool)
+	normalized := make(Namespaces, 0, len(namespaces))
+	for _, raw := range namespaces {
+		for ns := range strings.SplitSeq(raw, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns == "" || seen[ns] {
+				continue
+			}
+			seen[ns] = true
+			normalized = append(normalized, ns)
+		}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }
 
 type S3Config struct {
@@ -605,6 +683,8 @@ func (c *Config) fileNameInternal(res *GroupResource, namespace, name, templ str
 
 // Validate the config.
 func (c *Config) Validate() error {
+	c.Namespace = normalizeNamespaces(c.Namespace)
+
 	if c.FileNameTemplate == "" {
 		return errors.New("file name template must not be empty")
 	} else if _, err := c.FileName(&GroupResource{}, &unstructured.Unstructured{}, 0); err != nil {

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -374,39 +374,58 @@ func TestConfig_Validate(t *testing.T) {
 
 func TestConfig_Namespace(t *testing.T) {
 	tests := []struct {
-		name     string
-		config   string
-		expected types.Namespaces
+		name               string
+		config             string
+		expectedNamespace  string
+		expectedNamespaces []string
+		expectedFilter     []string
 	}{
 		{
-			name:     "should read a legacy namespace string",
-			config:   "namespace: default",
-			expected: types.Namespaces{"default"},
+			name:              "should read a singular namespace",
+			config:            "namespace: default",
+			expectedNamespace: "default",
+			expectedFilter:    []string{"default"},
 		},
 		{
-			name:     "should read comma-separated namespace string",
-			config:   "namespace: namespace-a,namespace-b",
-			expected: types.Namespaces{"namespace-a", "namespace-b"},
-		},
-		{
-			name: "should read namespace list",
-			config: `namespace:
+			name: "should read namespaces list",
+			config: `namespaces:
   - namespace-a
   - namespace-b`,
-			expected: types.Namespaces{"namespace-a", "namespace-b"},
+			expectedNamespaces: []string{"namespace-a", "namespace-b"},
+			expectedFilter:     []string{"namespace-a", "namespace-b"},
 		},
 		{
-			name:     "should ignore empty namespaces",
-			config:   "namespace: ''",
-			expected: nil,
+			name: "should read comma-separated namespaces string",
+			config: `namespaces:
+  - namespace-a,namespace-b`,
+			expectedNamespaces: []string{"namespace-a", "namespace-b"},
+			expectedFilter:     []string{"namespace-a", "namespace-b"},
 		},
 		{
-			name: "should deduplicate namespaces",
-			config: `namespace:
+			name: "should join namespace and namespaces",
+			config: `namespace: namespace-a
+namespaces:
+  - namespace-b
+  - namespace-c`,
+			expectedNamespace:  "namespace-a",
+			expectedNamespaces: []string{"namespace-b", "namespace-c"},
+			expectedFilter:     []string{"namespace-a", "namespace-b", "namespace-c"},
+		},
+		{
+			name: "should deduplicate joined namespaces",
+			config: `namespace: namespace-a
+namespaces:
   - namespace-a
-  - namespace-a
-  - namespace-b`,
-			expected: types.Namespaces{"namespace-a", "namespace-b"},
+  - namespace-b
+  - namespace-a`,
+			expectedNamespace:  "namespace-a",
+			expectedNamespaces: []string{"namespace-a", "namespace-b"},
+			expectedFilter:     []string{"namespace-a", "namespace-b"},
+		},
+		{
+			name:           "should ignore empty namespaces",
+			config:         "namespace: ''",
+			expectedFilter: nil,
 		},
 	}
 
@@ -416,8 +435,15 @@ func TestConfig_Namespace(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(tt.config), config); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(config.Namespace, tt.expected) {
-				t.Errorf("expected namespace %v, but got %v", tt.expected, config.Namespace)
+			config.Namespaces = types.NewNamespaces(config.Namespaces)
+			if config.Namespace != tt.expectedNamespace {
+				t.Errorf("expected namespace %q, but got %q", tt.expectedNamespace, config.Namespace)
+			}
+			if !reflect.DeepEqual(config.Namespaces, tt.expectedNamespaces) {
+				t.Errorf("expected namespaces %v, but got %v", tt.expectedNamespaces, config.Namespaces)
+			}
+			if !reflect.DeepEqual(config.NamespaceFilter(), tt.expectedFilter) {
+				t.Errorf("expected namespace filter %v, but got %v", tt.expectedFilter, config.NamespaceFilter())
 			}
 		})
 	}

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -366,6 +367,57 @@ func TestConfig_Validate(t *testing.T) {
 			}
 			if tt.validate != nil {
 				tt.validate(t, config)
+			}
+		})
+	}
+}
+
+func TestConfig_Namespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		expected types.Namespaces
+	}{
+		{
+			name:     "should read a legacy namespace string",
+			config:   "namespace: default",
+			expected: types.Namespaces{"default"},
+		},
+		{
+			name:     "should read comma-separated namespace string",
+			config:   "namespace: namespace-a,namespace-b",
+			expected: types.Namespaces{"namespace-a", "namespace-b"},
+		},
+		{
+			name: "should read namespace list",
+			config: `namespace:
+  - namespace-a
+  - namespace-b`,
+			expected: types.Namespaces{"namespace-a", "namespace-b"},
+		},
+		{
+			name:     "should ignore empty namespaces",
+			config:   "namespace: ''",
+			expected: nil,
+		},
+		{
+			name: "should deduplicate namespaces",
+			config: `namespace:
+  - namespace-a
+  - namespace-a
+  - namespace-b`,
+			expected: types.Namespaces{"namespace-a", "namespace-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, _ := setupConfig()
+			if err := yaml.Unmarshal([]byte(tt.config), config); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(config.Namespace, tt.expected) {
+				t.Errorf("expected namespace %v, but got %v", tt.expected, config.Namespace)
 			}
 		})
 	}


### PR DESCRIPTION
Changes

Updated Config fields
```
# Allow multiple namespaces
namespace:
  - namespace-a
  - namespace-b

# When a namespace filter is active, also export cluster-scoped resources
includeClusterResources: true
```
Updated CLI flags
```
--namespace strings            Export only these namespaces, comma-separated (e.g. --namespace ns1,ns2)or repeated (e.g. --namespace ns1 --namespace ns2)
--include-cluster-resources     Also export cluster-scoped resources when a namespace filter is active (e.g. --include-cluster-resources=true)
```